### PR TITLE
feat: 랜턴 목록 조회하기 API 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 **/.env.*
 **/k8s
 
+# logging files
+**/logs/
+
 # IDE configs (루트 및 하위 폴더 전부)
 .idea/
 .vscode/

--- a/backend/app/api/v1/lantern_api.py
+++ b/backend/app/api/v1/lantern_api.py
@@ -58,8 +58,11 @@ async def create_lanterns(
     }
 )
 async def get_lanterns(
-    current_lantern_id: Optional[str] = Query(default=None),
-    db=Depends(get_mongo_client)
+        current_lantern_id: Optional[str] = Query(
+            None,
+            description="현재 조회 중인 랜턴 ID",
+            regex=r"^[가-힣a-zA-Z0-9]+-[0-9]+$"
+        ), db=Depends(get_mongo_client)
 ):
     lantern_service = LanternService(db)
     lanterns = await lantern_service.get_recent_lanterns(current_lantern_id=current_lantern_id)

--- a/backend/app/api/v1/lantern_api.py
+++ b/backend/app/api/v1/lantern_api.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import APIRouter, Depends, UploadFile, File, Form, Query
 
 from app.core.db.database import get_mongo_client
@@ -45,7 +47,6 @@ async def create_lanterns(
     lantern_id = await lantern_service.create_lanterns(name, image)
     return success_response(data={"lantern_id": lantern_id}, message="Lantern Created")
 
-
 @router.get(
     "/lanterns",
     responses={
@@ -57,7 +58,7 @@ async def create_lanterns(
     }
 )
 async def get_lanterns(
-    current_lantern_id: str = Query(...),
+    current_lantern_id: Optional[str] = Query(default=None),
     db=Depends(get_mongo_client)
 ):
     lantern_service = LanternService(db)

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -3,6 +3,8 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    APP_ENV: str = "production"
+
     # MongoDB
     MONGO_URI: str = Field(...)
     MONGO_DB: str = Field(...)

--- a/backend/app/core/exceptions/handlers.py
+++ b/backend/app/core/exceptions/handlers.py
@@ -1,6 +1,5 @@
 import logging
-
-from fastapi import Request, HTTPException
+from fastapi import Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
@@ -11,32 +10,62 @@ from app.core.response.response import error_response
 logger = logging.getLogger("uvicorn.error")
 
 
-# HTTPException 처리 핸들러
-async def http_exception_handler(request: Request, exc: HTTPException):
-    logger.error(f"HTTPException: {exc.detail} (status: {exc.status_code})")
-    response = error_response(message=exc.detail)
-    return JSONResponse(
-        status_code=exc.status_code,
-        content=response.dict()
+# RequestValidationError 처리 핸들러 (400 Bad Request)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    first_error = exc.errors()[0]["msg"] if exc.errors() else "입력 형식이 올바르지 않습니다."
+    response = error_response(
+        message="입력 형식이 올바르지 않습니다.",
+        error_code="INVALID_INPUT_FORMAT"
     )
 
+    logger.warning(
+        "[ValidationError] %s %s | Error: %s | Response: %s",
+        request.method,
+        request.url.path,
+        first_error,
+        response.dict()
+    )
 
-# RequestValidationError 처리 핸들러
-async def validation_exception_handler(request: Request, exc: RequestValidationError):
-    first_error = exc.errors()[0]["msg"] if exc.errors() else "Invalid request"
-    logger.error(f"RequestValidationError: {first_error}")
-    response = error_response(message=first_error)
     return JSONResponse(
-        status_code=422,
+        status_code=400,
         content=response.dict()
     )
 
 
 # AppError (커스텀 예외) 처리 핸들러
 async def app_error_handler(request: Request, exc: AppError):
-    logger.error(f"AppError: {exc}")
-    response = error_response(message=str(exc))
+    status_code = getattr(exc, 'status_code', 500)
+    error_code = getattr(exc, 'error_code', 'UNKNOWN_ERROR')
+    message = str(exc)
+
+    response = error_response(
+        message=message,
+        error_code=error_code
+    )
+
+    logger.error(
+        "[AppError] %s %s | ErrorCode: %s | Message: %s | Response: %s",
+        request.method,
+        request.url.path,
+        error_code,
+        message,
+        response.dict()
+    )
+
     return JSONResponse(
-        status_code=getattr(exc, 'status_code', 500),
+        status_code=status_code,
+        content=response.dict()
+    )
+
+
+# 500 Internal Server Error용 핸들러
+async def generic_exception_handler(request: Request, exc: Exception):
+    logger.exception(f"[Unhandled Exception] {request.method} {request.url.path} - {exc}")
+    response = error_response(
+        message="서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+        error_code="INTERNAL_SERVER_ERROR"
+    )
+    return JSONResponse(
+        status_code=500,
         content=response.dict()
     )

--- a/backend/app/core/exceptions/handlers.py
+++ b/backend/app/core/exceptions/handlers.py
@@ -1,12 +1,12 @@
 import logging
 import traceback
+
 from fastapi import Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
-from app.core.exceptions.types import AppError
-from app.core.response.response import error_response
 from app.core.config.settings import settings  # 환경 구분용
+from app.core.exceptions.types import AppError
 
 # 로거 설정
 logger = logging.getLogger("uvicorn.error")

--- a/backend/app/core/exceptions/handlers.py
+++ b/backend/app/core/exceptions/handlers.py
@@ -1,10 +1,12 @@
 import logging
+import traceback
 from fastapi import Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from app.core.exceptions.types import AppError
 from app.core.response.response import error_response
+from app.core.config.settings import settings  # 환경 구분용
 
 # 로거 설정
 logger = logging.getLogger("uvicorn.error")
@@ -13,22 +15,32 @@ logger = logging.getLogger("uvicorn.error")
 # RequestValidationError 처리 핸들러 (400 Bad Request)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     first_error = exc.errors()[0]["msg"] if exc.errors() else "입력 형식이 올바르지 않습니다."
-    response = error_response(
-        message="입력 형식이 올바르지 않습니다.",
-        error_code="INVALID_INPUT_FORMAT"
-    )
+
+    response_data = {
+        "status": "error",
+        "error_code": "INVALID_INPUT_FORMAT",
+        "message": "입력 형식이 올바르지 않습니다."
+    }
+
+    # 개발 환경이면 debug info 추가
+    if settings.APP_ENV == "development":
+        response_data["debug_info"] = {
+            "location": f"{request.method} {request.url.path}",
+            "exception": type(exc).__name__,
+            "stack_trace": traceback.format_exc()
+        }
 
     logger.warning(
         "[ValidationError] %s %s | Error: %s | Response: %s",
         request.method,
         request.url.path,
         first_error,
-        response.dict()
+        response_data
     )
 
     return JSONResponse(
         status_code=400,
-        content=response.dict()
+        content=response_data
     )
 
 
@@ -38,10 +50,19 @@ async def app_error_handler(request: Request, exc: AppError):
     error_code = getattr(exc, 'error_code', 'UNKNOWN_ERROR')
     message = str(exc)
 
-    response = error_response(
-        message=message,
-        error_code=error_code
-    )
+    response_data = {
+        "status": "error",
+        "error_code": error_code,
+        "message": message
+    }
+
+    # 개발 환경이면 debug info 추가
+    if settings.APP_ENV == "development":
+        response_data["debug_info"] = {
+            "location": f"{request.method} {request.url.path}",
+            "exception": type(exc).__name__,
+            "stack_trace": traceback.format_exc()
+        }
 
     logger.error(
         "[AppError] %s %s | ErrorCode: %s | Message: %s | Response: %s",
@@ -49,23 +70,33 @@ async def app_error_handler(request: Request, exc: AppError):
         request.url.path,
         error_code,
         message,
-        response.dict()
+        response_data
     )
 
     return JSONResponse(
         status_code=status_code,
-        content=response.dict()
+        content=response_data
     )
 
 
-# 500 Internal Server Error용 핸들러
+# 500 Internal Server Error 처리 핸들러
 async def generic_exception_handler(request: Request, exc: Exception):
     logger.exception(f"[Unhandled Exception] {request.method} {request.url.path} - {exc}")
-    response = error_response(
-        message="서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
-        error_code="INTERNAL_SERVER_ERROR"
-    )
+
+    response_data = {
+        "status": "error",
+        "error_code": "INTERNAL_SERVER_ERROR",
+        "message": "서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+    }
+
+    if settings.APP_ENV == "development":
+        response_data["debug_info"] = {
+            "location": f"{request.method} {request.url.path}",
+            "exception": type(exc).__name__,
+            "stack_trace": traceback.format_exc()
+        }
+
     return JSONResponse(
         status_code=500,
-        content=response.dict()
+        content=response_data
     )

--- a/backend/app/core/exceptions/types.py
+++ b/backend/app/core/exceptions/types.py
@@ -1,41 +1,51 @@
 class AppError(Exception):
     """Base class for all custom application exceptions."""
     status_code = 500
+    error_code = "APP_ERROR"
 
-    def __init__(self, message="Application error"):
+    def __init__(self, message="Application error", error_code=None):
         self.message = message
+        self.error_code = error_code or self.error_code
         super().__init__(message)
 
 
 class DatabaseError(AppError):
     """Raised when a database operation fails."""
-    def __init__(self, message="Database operation failed"):
-        super().__init__(message)
+    error_code = "DATABASE_ERROR"
+
+    def __init__(self, message="Database operation failed", error_code=None):
+        super().__init__(message=message, error_code=error_code or self.error_code)
 
 
 class FileSaveError(AppError):
     """Raised when file saving fails."""
-    def __init__(self, message="File saving failed"):
-        super().__init__(message)
+    error_code = "FILE_SAVE_ERROR"
+
+    def __init__(self, message="File saving failed", error_code=None):
+        super().__init__(message=message, error_code=error_code or self.error_code)
 
 
 class ValidationError(AppError):
     """Raised when input validation fails."""
     status_code = 400
+    error_code = "VALIDATION_ERROR"
 
-    def __init__(self, message="Validation error"):
-        super().__init__(message)
+    def __init__(self, message="Validation error", error_code=None):
+        super().__init__(message=message, error_code=error_code or self.error_code)
 
 
 class NotFoundError(AppError):
     """Raised when a requested resource is not found."""
     status_code = 404
+    error_code = "NOT_FOUND"
 
-    def __init__(self, message="Resource not found"):
-        super().__init__(message)
+    def __init__(self, message="Resource not found", error_code=None):
+        super().__init__(message=message, error_code=error_code or self.error_code)
 
 
 class AIResponseProcessingError(AppError):
     """Raised when AI response processing failed."""
-    def __init__(self, message="AI response processing failed"):
-        super().__init__(message)
+    error_code = "AI_RESPONSE_PROCESSING_ERROR"
+
+    def __init__(self, message="AI response processing failed", error_code=None):
+        super().__init__(message=message, error_code=error_code or self.error_code)

--- a/backend/app/core/logging/logger.py
+++ b/backend/app/core/logging/logger.py
@@ -16,6 +16,7 @@ def get_logger(name: str):
         logger.addHandler(stream_handler)
 
         # 파일 로그 핸들러
+        os.makedirs("logs", exist_ok=True)
         file_handler = logging.FileHandler("logs/app.log", encoding="utf-8")
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)

--- a/backend/app/core/logging/logger.py
+++ b/backend/app/core/logging/logger.py
@@ -1,14 +1,24 @@
 import logging
+import os
 
 
 def get_logger(name: str):
     logger = logging.getLogger(name)
-    logger.setLevel(logging.INFO)
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    logger.setLevel(getattr(logging, log_level, logging.INFO))
 
     if not logger.handlers:
-        handler = logging.StreamHandler()
         formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s - %(message)s")
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
 
+        # 콘솔 로그 핸들러
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(formatter)
+        logger.addHandler(stream_handler)
+
+        # 파일 로그 핸들러
+        file_handler = logging.FileHandler("logs/app.log", encoding="utf-8")
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    logger.propagate = False
     return logger

--- a/backend/app/core/response/response.py
+++ b/backend/app/core/response/response.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from app.schemas.schemas import ResponseModel
+from app.schemas.schemas import ResponseModel, ErrorResponseModel
 
 
 def success_response(data: Any, message: str = "Success"):
@@ -11,9 +11,9 @@ def success_response(data: Any, message: str = "Success"):
     )
 
 
-def error_response(message: str = "An error occurred"):
-    return ResponseModel(
+def error_response(message: str = "An error occurred", error_code: str = "UNKNOWN_ERROR"):
+    return ErrorResponseModel(
         status="error",
-        message=message,
-        data=None
+        error_code=error_code,
+        message=message
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,8 @@ from starlette.middleware.cors import CORSMiddleware
 from app.api.v1.routers import api_router
 from app.core.config.settings import settings
 from app.core.db.database import lifespan
-from app.core.exceptions.handlers import http_exception_handler, validation_exception_handler, app_error_handler
+from app.core.exceptions.handlers import validation_exception_handler, app_error_handler, \
+    generic_exception_handler
 from app.core.exceptions.types import AppError
 
 app = FastAPI(lifespan=lifespan)
@@ -24,8 +25,8 @@ app.add_middleware(
 
 app.include_router(api_router, prefix=settings.API_PREFIX)
 
-app.add_exception_handler(HTTPException, http_exception_handler)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
 app.add_exception_handler(AppError, app_error_handler)
+app.add_exception_handler(Exception, generic_exception_handler)
 
 

--- a/backend/app/repositories/lantern_repository.py
+++ b/backend/app/repositories/lantern_repository.py
@@ -1,4 +1,6 @@
-from app.core.exceptions.types import DatabaseError
+from typing import Optional
+
+from app.core.exceptions.types import DatabaseError, NotFoundError
 
 
 class LanternRepository:
@@ -31,3 +33,19 @@ class LanternRepository:
             return await self.collection.count_documents(filter_dict)
         except Exception as e:
             raise DatabaseError(f"Database count failed: {e}") from e
+
+    async def find_random_lanterns(self, limit: int = 20, exclude_lantern_id: Optional[str] = None):
+        try:
+            match_stage = {"is_public": True}
+            if exclude_lantern_id:
+                match_stage["lantern_id"] = {"$ne": exclude_lantern_id}
+
+            pipeline = [
+                {"$match": match_stage},
+                {"$sample": {"size": limit}}
+            ]
+            cursor = self.collection.aggregate(pipeline)
+            return [doc async for doc in cursor]
+        except Exception as e:
+            raise DatabaseError(f"Database random sample failed: {e}") from e
+

--- a/backend/app/schemas/db/lantern.py
+++ b/backend/app/schemas/db/lantern.py
@@ -15,6 +15,7 @@ class LanternDBModel(BaseModel):
     original_filename: Optional[str] = None
     file_extension: Optional[str] = None
     file_size: Optional[int] = None
+    is_public: bool
     created_at: datetime
 
     @field_serializer('id')

--- a/backend/app/schemas/response/lantern_list_response.py
+++ b/backend/app/schemas/response/lantern_list_response.py
@@ -4,5 +4,4 @@ from pydantic import BaseModel
 class LanternListResponseModel(BaseModel):
     lantern_id: str
     owner_name: str
-    emotion: str
     is_current_lantern: bool

--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -7,3 +7,9 @@ class ResponseModel(BaseModel):
     status: str
     message: str
     data: Any = None
+
+
+class ErrorResponseModel(BaseModel):
+    status: str
+    error_code: str
+    message: str

--- a/backend/app/services/lantern_service.py
+++ b/backend/app/services/lantern_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 from uuid import uuid4
 
 from app.core.exceptions.types import FileSaveError, ValidationError, NotFoundError
@@ -41,28 +42,33 @@ class LanternService:
         generate_panorama_task.delay(prompt=name, lantern_id=lantern_id, image_path=file_path)
 
         return lantern_id
+    def to_lantern_model(self, doc: dict, current_lantern_id: Optional[str]) -> LanternListResponseModel:
+        return LanternListResponseModel(
+            lantern_id=doc["lantern_id"],
+            owner_name=doc["user_name"],
+            is_current_lantern=(doc["lantern_id"] == current_lantern_id)
+        )
 
-    async def get_recent_lanterns(self, current_lantern_id: str, limit: int = 20):
+    async def get_recent_lanterns(self, current_lantern_id: Optional[str] = None, limit: int = 20):
+        current_doc = None
+
         if current_lantern_id:
-            count = await self.lantern_repo.count_documents({"lantern_id": current_lantern_id})
-            if count == 0:
-                raise NotFoundError(f"Current Lantern ID {current_lantern_id} not found.")
+            current_doc = await self.lantern_repo.find_by_lantern_id(current_lantern_id)
+            if not current_doc:
+                raise NotFoundError(
+                    message=f"Lantern ID {current_lantern_id} not found.",
+                    error_code="LANTERN_NOT_FOUND"
+                )
+            limit -= 1
 
-        recent_lanterns = await self.lantern_repo.find_recent_lanterns(limit)
-        lanterns = []
+        other_docs = await self.lantern_repo.find_random_lanterns(
+            exclude_lantern_id=current_lantern_id if current_doc else None,
+            limit=limit
+        )
 
-        for lantern_doc in recent_lanterns:
-            music = await self.music_repo.find_music_by_lantern_id(lantern_doc["lantern_id"])
+        docs = [current_doc] + other_docs if current_doc else other_docs
 
-            lantern = LanternListResponseModel(
-                lantern_id=lantern_doc["lantern_id"],
-                owner_name=lantern_doc["user_name"],
-                emotion=music.get("prompt", "unknown") if music else "unknown",
-                is_current_lantern=(lantern_doc["lantern_id"] == current_lantern_id)
-            )
-            lanterns.append(lantern)
-
-        return lanterns
+        return [self.to_lantern_model(doc, current_lantern_id) for doc in docs]
 
     async def get_lantern_detail(self, lantern_id: str, current_lantern_id: str):
         if current_lantern_id:


### PR DESCRIPTION
<!-- PR의 제목은 "feat: 로그인 기능 추가" 와 같이 작성해주세요! -->
<!-- 커밋 컨벤션과 PR 제목은 통일하고 스쿼시머지를 진행합니다 -->

## 🔢 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #36 

## 🎈 PR 유형

어떤 변경 사항이 있나요?

- [X] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## 🔑 Key Changes

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 바뀐 API 스펙에 맞게 모두 적용 
  - 바뀐 기능 정리
    - current_lantern_id가 포함해서 요청이 올 경우 -> 포함해서 20개 랜턴 반환
    - 포함 X 요청이 올 경우 -> 제외하고 19개 랜턴 반환
    - 나머지 랜턴은 is_public=true일 경우 내에서 랜덤으로 추출
    - 실제 전시를 할 때 샘플 랜턴 4개 준비(각자꺼)
    - 랜턴마다 색깔을 보여주기 기능은 삭제 -> 응답값 DTO 수정
- 추가로 로깅한 메시지들 확인할 수 있도록 폴더 지정 및 저장 로직 추가
- 예외 기능 디벨롭
  - 운영환경과 개발환경에 따른 메시지 다르게 
  - 예외 코드 추가 
  - 관련해서는 API 문서 예외처리에 자세히 적었으니 참고 부탁드립니다.  

## 📢 To Reviewers

<!-- 함께 의논할 부분이 있다면 작성해주세요 -->

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 최근 랜턴 목록 조회 시 현재 랜턴과 무작위로 선택된 공개 랜턴들을 함께 반환하는 기능이 추가되었습니다.
  * 에러 응답에 표준화된 에러 코드와 메시지, 상태값이 포함됩니다.
  * 환경 설정에 APP_ENV 변수가 추가되어 개발/운영 환경 구분이 가능해졌습니다.

* **버그 수정**
  * 예외 처리 및 에러 응답 포맷이 통일되어, 입력 오류나 서버 오류 발생 시 일관된 메시지와 코드가 제공됩니다.

* **개선 및 변경**
  * 랜턴 조회 시 현재 조회 중인 랜턴 ID를 선택적으로 입력할 수 있도록 개선되었습니다.
  * 랜턴 응답 모델에서 emotion 필드가 제거되었습니다.
  * 로그 파일이 별도 디렉터리에 저장되고, 로그 레벨을 환경 변수로 제어할 수 있게 변경되었습니다.
  * 랜턴 데이터 모델에 공개 여부(is_public) 필드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->