### PR TITLE
feat: Last-Event-ID와 resume 쿼리 파라미터를 활용한 SSE 재연결 기능 추가

### DIFF
--- a/ai-server/app/music/run_musicgen.py
+++ b/ai-server/app/music/run_musicgen.py
@@ -18,7 +18,6 @@ def init_model():
     global model
     if model is None:
         model = MusicGen.get_pretrained("facebook/musicgen-small", device=device)
-        model.compression_model.to(device)
 
 def generate_music(image: str, duration: int = 10) -> dict:
     init_model()

--- a/backend/app/api/v1/lantern_api.py
+++ b/backend/app/api/v1/lantern_api.py
@@ -3,7 +3,7 @@ import json
 import time
 from typing import Optional, List
 
-from fastapi import APIRouter, UploadFile, File, Form, Query, Path, Request
+from fastapi import APIRouter, UploadFile, File, Form, Query, Path, Request, Header
 from sse_starlette.sse import EventSourceResponse
 
 from app.core.config.settings import settings
@@ -36,12 +36,18 @@ async def music_status(
         ...,
         description="조회할 랜턴의 ID",
         regex=r"^[가-힣a-zA-Z0-9]+-[0-9]{4}$"
-    )
+    ),
+    resume: bool = Query(False, description="이전 이벤트 ID를 기반으로 이어받을지 여부"),
+    last_event_id: Optional[str] = Header(None, convert_underscores=False)
 ):
     db = get_mongo_client(request)
     repo = LanternRepository(db)
     start_time = time.time()
     sent_task_ids = set()
+
+    if resume and last_event_id:
+        sent_task_ids.add(last_event_id)
+
     polling_interval = getattr(settings, 'SSE_POLLING_INTERVAL', 3)
 
     async def event_generator():
@@ -49,7 +55,6 @@ async def music_status(
             try:
                 if await request.is_disconnected():
                     break
-
                 if time.time() - start_time > settings.SSE_TIMEOUT:
                     break
 
@@ -62,23 +67,26 @@ async def music_status(
                     break
 
                 statuses = doc.get("music_statuses", [])
-
                 new_completed = [
                     s for s in statuses
                     if s["status"] == "success" and s["task_id"] not in sent_task_ids
                 ]
                 for s in new_completed:
                     yield {
+                        "id": s["task_id"],
                         "event": "music_done_partial",
                         "data": json.dumps(s)
                     }
                     sent_task_ids.add(s["task_id"])
 
                 if all(s["status"] == "success" for s in statuses) and len(statuses) > 0:
-                    yield {
-                        "event": "music_done_all",
-                        "data": json.dumps(statuses)
-                    }
+                    if "done-all" not in sent_task_ids:
+                        yield {
+                            "id": "done-all",
+                            "event": "music_done_all",
+                            "data": json.dumps(statuses)
+                        }
+                        sent_task_ids.add("done-all")
                     break
 
             except Exception as e:

--- a/backend/app/api/v1/lantern_api.py
+++ b/backend/app/api/v1/lantern_api.py
@@ -48,7 +48,7 @@ async def music_status(
 
     doc = await repo.find_by_lantern_id(lantern_id)
     if not doc:
-        raise NotFoundError("Lantern not found")
+        raise NotFoundError(f"Lantern ID '{lantern_id}' not found")
 
     if resume and last_event_id:
         valid_ids = {s["task_id"] for s in doc.get("music_statuses", [])}

--- a/backend/app/api/v1/lantern_api.py
+++ b/backend/app/api/v1/lantern_api.py
@@ -8,7 +8,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from app.core.config.settings import settings
 from app.core.db.database import get_mongo_client
-from app.core.exceptions.types import InvalidResumeEventError
+from app.core.exceptions.types import InvalidResumeEventError, NotFoundError
 from app.core.response.response import success_response
 from app.core.validation.lantern_validation import validate_name, validate_images
 from app.repositories.lantern_repository import LanternRepository
@@ -46,6 +46,10 @@ async def music_status(
     start_time = time.time()
     sent_task_ids = set()
 
+    doc = await repo.find_by_lantern_id(lantern_id)
+    if not doc:
+        raise NotFoundError("Lantern not found")
+
     if resume and last_event_id:
         valid_ids = {s["task_id"] for s in doc.get("music_statuses", [])}
         if last_event_id in valid_ids:
@@ -56,6 +60,7 @@ async def music_status(
     polling_interval = getattr(settings, 'SSE_POLLING_INTERVAL', 3)
 
     async def event_generator():
+        nonlocal doc
         while True:
             try:
                 if await request.is_disconnected():

--- a/backend/app/api/v1/lantern_api.py
+++ b/backend/app/api/v1/lantern_api.py
@@ -8,6 +8,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from app.core.config.settings import settings
 from app.core.db.database import get_mongo_client
+from app.core.exceptions.types import InvalidResumeEventError
 from app.core.response.response import success_response
 from app.core.validation.lantern_validation import validate_name, validate_images
 from app.repositories.lantern_repository import LanternRepository
@@ -46,7 +47,11 @@ async def music_status(
     sent_task_ids = set()
 
     if resume and last_event_id:
-        sent_task_ids.add(last_event_id)
+        valid_ids = {s["task_id"] for s in doc.get("music_statuses", [])}
+        if last_event_id in valid_ids:
+            sent_task_ids.add(last_event_id)
+        else:
+            raise InvalidResumeEventError(last_event_id)
 
     polling_interval = getattr(settings, 'SSE_POLLING_INTERVAL', 3)
 

--- a/backend/app/core/exceptions/types.py
+++ b/backend/app/core/exceptions/types.py
@@ -45,3 +45,11 @@ class ForbiddenError(AppError):
 
     def __init__(self, message="Access denied", error_code=None):
         super().__init__(message=message, error_code=error_code)
+
+class InvalidResumeEventError(AppError):
+    status_code = 400
+    error_code = "INVALID_RESUME_EVENT"
+
+    def __init__(self, last_event_id=None):
+        msg = f"Invalid resume event id: {last_event_id}" if last_event_id else "Invalid resume event id"
+        super().__init__(message=msg, error_code=self.error_code)


### PR DESCRIPTION
<!-- PR의 제목은 "feat: 로그인 기능 추가" 와 같이 작성해주세요! -->
<!-- 커밋 컨벤션과 PR 제목은 통일하고 스쿼시머지를 진행합니다 -->

## 🔢 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #55 

## 🎈 PR 유형

어떤 변경 사항이 있나요?

- [X] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [X] 리팩토링

## 🔑 Key Changes

- 클라이언트가 SSE 연결이 끊어진 후 재연결할 경우, Last-Event-ID 헤더와 resume=true 쿼리 파라미터를 활용하여 이전에 수신하지 못한 이벤트부터 이어받을 수 있도록 지원했습니다.
- 서버는 Last-Event-ID 값을 기준으로 해당 클라이언트에 중복 없이 누락된 이벤트만 전송하도록 처리했습니다.
- resume 파라미터가 없거나 false인 경우에는 항상 최초 상태부터 전체 이벤트를 새로 전송합니다.
- 이벤트 ID(id:)는 task_id 또는 done-all로 명확히 지정되어 클라이언트가 이어받기 쉬운 구조로 개선했습니다.

## 📢 To Reviewers

<!-- 함께 의논할 부분이 있다면 작성해주세요 -->

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * 이벤트 스트림을 이전 이벤트 ID 기준으로 이어받을 수 있는 기능이 추가되었습니다.
  * 각 부분별 음악 생성 이벤트와 최종 완료 이벤트에 고유 ID가 포함되어, 클라이언트에서 이벤트 추적이 용이해졌습니다.

* **Bug Fixes**
  * 중복된 이벤트(특히 "all done" 이벤트)가 재전송되지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->