### PR TITLE
fix: 랜턴 목록 API 브라우저 캐싱 비활성화

### DIFF
--- a/backend/app/api/v1/lantern_api.py
+++ b/backend/app/api/v1/lantern_api.py
@@ -9,7 +9,7 @@ from sse_starlette.sse import EventSourceResponse
 from app.core.config.settings import settings
 from app.core.db.database import get_mongo_client
 from app.core.exceptions.types import InvalidResumeEventError, NotFoundError
-from app.core.response.response import success_response
+from app.core.response.response import success_response, success_no_cache_response
 from app.core.validation.lantern_validation import validate_name, validate_images
 from app.repositories.lantern_repository import LanternRepository
 from app.schemas.response.lantern_detail_response import LanternDetailResponseModel
@@ -161,7 +161,7 @@ async def get_lantern_list(
     db = get_mongo_client(request)
     lantern_service = LanternService(db)
     lanterns = await lantern_service.get_recent_lanterns(current_lantern_id=current_lantern_id)
-    return success_response(
+    return success_no_cache_response(
         data=[lantern.model_dump() for lantern in lanterns],
         message="Lantern list"
     )

--- a/backend/app/core/response/response.py
+++ b/backend/app/core/response/response.py
@@ -21,9 +21,10 @@ def error_response(message: str = "An error occurred", error_code: str = "UNKNOW
     )
 
 
-def success_no_cache_response(data, message="Success"):
+def success_no_cache_response(data: Any, message: str = "Success"):
+    model = success_response(data=data, message=message)
     return JSONResponse(
-        content={"message": message, "data": data},
+        content=model.model_dump(),
         headers={
             "Cache-Control": "no-store, no-cache, must-revalidate",
             "Pragma": "no-cache",

--- a/backend/app/core/response/response.py
+++ b/backend/app/core/response/response.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from fastapi.responses import JSONResponse
+
 from app.schemas.response.schemas import ResponseModel, ErrorResponseModel
 
 
@@ -16,4 +18,15 @@ def error_response(message: str = "An error occurred", error_code: str = "UNKNOW
         status="error",
         error_code=error_code,
         message=message
+    )
+
+
+def success_no_cache_response(data, message="Success"):
+    return JSONResponse(
+        content={"message": message, "data": data},
+        headers={
+            "Cache-Control": "no-store, no-cache, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0"
+        }
     )


### PR DESCRIPTION
<!-- PR의 제목은 "feat: 로그인 기능 추가" 와 같이 작성해주세요! -->
<!-- 커밋 컨벤션과 PR 제목은 통일하고 스쿼시머지를 진행합니다 -->

## 🔢 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #64 

## 🎈 PR 유형

어떤 변경 사항이 있나요?

- [ ] 새 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## 🔑 Key Changes

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- `/api/v1/lanterns` 응답 헤더에 캐시 비활성화 옵션 추가  
  (`Cache-Control: no-store, no-cache, must-revalidate`, `Pragma: no-cache`, `Expires: 0`)
- React Query 캐싱 문제로 동일한 랜턴 목록이 반복 노출되는 이슈 해결


## 📢 To Reviewers

<!-- 함께 의논할 부분이 있다면 작성해주세요 -->
- 캐시가 필요 없는 API로 판단하여 서버 응답단에서만 수정했습니다.  
  추가로 React Query `cacheTime` 조정이 필요할지 프론트와 논의가 필요합니다.


## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 캐시를 방지하는 새로운 성공 응답 방식이 추가되어, 일부 API 응답이 항상 최신 정보로 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->